### PR TITLE
Force use of Wayland

### DIFF
--- a/sonic-appimage.sh
+++ b/sonic-appimage.sh
@@ -25,7 +25,7 @@ ln -s unleashedrecomp.png ./.DirIcon
 
 echo '[Desktop Entry]
 Name=Unleashed Recompiled
-Exec=UnleashedRecomp
+Exec=UnleashedRecomp --sdl-video-driver wayland
 Type=Application
 Icon=unleashedrecomp
 Categories=Game;


### PR DESCRIPTION
Even if Wayland is available, Xorg/X11 is what is being used, I assume adding this command after the executable will solve this.